### PR TITLE
refactor: do not specify unecessary syntax plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   plugins: [
     require('babel-plugin-external-helpers'),
-    require('babel-plugin-syntax-trailing-function-commas'),
     require('babel-plugin-transform-async-to-generator'),
     require('babel-plugin-transform-class-properties'),
     require('babel-plugin-transform-es2015-destructuring'),
@@ -9,7 +8,6 @@ module.exports = {
     require('babel-plugin-transform-es2015-spread'),
     require('babel-plugin-transform-exponentiation-operator'),
     require('babel-plugin-transform-object-rest-spread'),
-    require('babel-plugin-syntax-flow'),
     require('babel-plugin-transform-flow-strip-types')
   ]
 };

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "homepage": "https://github.com/zacharygolba/babel-preset-lux#readme",
   "dependencies": {
     "babel-plugin-external-helpers": "^6.8.0",
-    "babel-plugin-syntax-flow": "^6.8.0",
-    "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-class-properties": "^6.9.1",
     "babel-plugin-transform-es2015-destructuring": "^6.9.0",


### PR DESCRIPTION
> NOTE: Transform plugins automatically inherit/use the syntax plugins so you don’t need to specify the syntax plugin if the corresponding transform plugin is used already.
> 
> \- [_Babel Docs_](http://babeljs.io/docs/plugins/#syntax-plugins)
